### PR TITLE
Remove GFX-library includes from examples. The lib header already has…

### DIFF
--- a/Adafruit_TFTLCD_8bit_STM32.h
+++ b/Adafruit_TFTLCD_8bit_STM32.h
@@ -7,7 +7,7 @@
 #define _ADAFRUIT_TFTLCD_8BIT_STM32_H_
 
 
-#include <Adafruit_GFX_AS.h>
+#include <Adafruit_GFX.h>
 
 #include <libmaple/gpio.h>
 

--- a/README.txt
+++ b/README.txt
@@ -8,4 +8,4 @@ Contribution from users for other display control types is welcome and made easy
 How to use:
 - Place the Adafruit_TFT library folder your <arduinosketchfolder>/libraries/ folder. You may need to create the libraries subfolder if its your first library. Restart the IDE.
 
-- Also requires the Adafruit_GFX library for Arduino. https://github.com/adafruit/Adafruit-GFX-Library
+- Also requires the Adafruit_GFX library for Arduino. https://github.com/adafruit/Adafruit-GFX-Library . Alternatively, you can change Adafruit_TFTLCD_8bit_STM32.h to #include <Adafruit_GFX_AS.h>, instead.

--- a/examples/Birduino/Birduino.ino
+++ b/examples/Birduino/Birduino.ino
@@ -14,7 +14,6 @@
 #include <EEPROM.h>
 */
 
-#include <Adafruit_GFX.h>    // Core graphics library
 #include <Adafruit_TFTLCD_8bit_STM32.h> // Hardware-specific library
 #include <TouchScreen_STM32.h>
 

--- a/examples/FolderBrowser/FolderBrowser.ino
+++ b/examples/FolderBrowser/FolderBrowser.ino
@@ -3,8 +3,7 @@
 // If using an Arduino Mega make sure to use its hardware SPI pins, OR make
 // sure the SD library is configured for 'soft' SPI in the file Sd2Card.h.
 
-#include <Adafruit_GFX.h>    // Core graphics library
-#include <Adafruit_TFTLCD.h> // Hardware-specific library
+#include <Adafruit_TFTLCD_8bit_STM32.h> // Hardware-specific library
 #include <SD.h>
 #include <SPI.h>
 

--- a/examples/rotationtest/rotationtest.ino
+++ b/examples/rotationtest/rotationtest.ino
@@ -2,7 +2,6 @@
 // CONFIGURED FOR EITHER THE TFT SHIELD OR THE BREAKOUT BOARD.
 // SEE RELEVANT COMMENTS IN Adafruit_TFTLCD.h FOR SETUP.
 
-#include <Adafruit_GFX.h>    // Core graphics library
 #include <Adafruit_TFTLCD_8bit_STM32.h> // Hardware-specific library
 
 // check the pin connections in the header file.

--- a/examples/tftbmp/tftbmp.ino
+++ b/examples/tftbmp/tftbmp.ino
@@ -3,8 +3,7 @@
 // If using an Arduino Mega make sure to use its hardware SPI pins, OR make
 // sure the SD library is configured for 'soft' SPI in the file Sd2Card.h.
 
-#include <Adafruit_GFX.h>    // Core graphics library
-#include <Adafruit_TFTLCD.h> // Hardware-specific library
+#include <Adafruit_TFTLCD_8bit_STM32.h> // Hardware-specific library
 #include <SD.h>
 #include <SPI.h>
 

--- a/examples/tftpaint/tftpaint.ino
+++ b/examples/tftpaint/tftpaint.ino
@@ -4,7 +4,6 @@
 // Uses double click/touch to clear the background in selected colour.
 // Uses double click/touch to set paint radius back to original value.
 
-#include <Adafruit_GFX.h>    // Core graphics library
 #include <Adafruit_TFTLCD_8bit_STM32.h> // Hardware-specific library
 #include <TouchScreen_STM32.h>
 


### PR DESCRIPTION
… one.

See https://github.com/stevstrong/Adafruit_TFTLCD_8bit_STM32/issues/7 .

I've also changed the lib-header to include Adafruit_GFX.h, instead of the AS-variant. If that is controversial, please just strip it.